### PR TITLE
feat: remove hungarian casing for interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ module.exports = {
       {
         'selector': 'interface',
         'format': ['PascalCase'],
-        'prefix': ['I'],
       },
       {
         'selector': 'class',

--- a/tests/rules/naming-convention.spec.ts
+++ b/tests/rules/naming-convention.spec.ts
@@ -15,21 +15,10 @@ describe('Flitto Custom Naming Convention Linting Rule Test', () => {
 
   describe('@typescript-eslint/naming-convention', () => {
     const targetDir = 'tests/rules/target/naming-convention'
-    it('인터페이스 이름의 Prefix 로 `I` 가 포함되어있지 않으면 린트에러가 발생합니다.', async () => {
-      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'interface_prefix_not_started_with_I.ts'))
+    it('인터페이스의 이름은 PascalCase 이어야 합니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'interface_name_as_camel_case.ts'))
       expect(results[0].messages.length).toEqual(1)
-      expect(results[0].messages[0].message).toEqual('Interface name `NotStartedWithI` must have one of the following prefixes: I')
-    })
-
-    it('인터페이스 이름의 Prefix 로 `I` 가 포함되어있어야 합니다.', async () => {
-      const results = await lint.lintFiles(Path.join(targetDir, VALID, 'interface_prefix.ts'))
-      expect(results[0].messages.length).toEqual(0)
-    })
-
-    it('클래스의 이름이 PascalCase 가 아니라면 린트에러가 발생합니다.', async () => {
-      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'class_name_as_camel_case.ts'))
-      expect(results[0].messages.length).toEqual(1)
-      expect(results[0].messages[0].message).toEqual('Class name `camelCaseClass` must match one of the following formats: PascalCase')
+      expect(results[0].messages[0].message).toEqual('Interface name `interfaceCamelCase` must match one of the following formats: PascalCase')
     })
 
     it('클래스의 이름은 PascalCase 이어야 합니다.', async () => {

--- a/tests/rules/target/naming-convention/invalid/interface_name_as_camel_case.ts
+++ b/tests/rules/target/naming-convention/invalid/interface_name_as_camel_case.ts
@@ -1,0 +1,4 @@
+interface interfaceCamelCase {
+  bar: number
+  foo: string
+}

--- a/tests/rules/target/naming-convention/invalid/interface_prefix_not_started_with_I.ts
+++ b/tests/rules/target/naming-convention/invalid/interface_prefix_not_started_with_I.ts
@@ -1,4 +1,0 @@
-interface NotStartedWithI {
-  bar: number
-  foo: string
-}

--- a/tests/rules/target/naming-convention/valid/interface_casing.ts
+++ b/tests/rules/target/naming-convention/valid/interface_casing.ts
@@ -1,0 +1,4 @@
+interface PascalCaseInterface {
+  bar: number
+  foo: string
+}

--- a/tests/rules/target/naming-convention/valid/interface_prefix.ts
+++ b/tests/rules/target/naming-convention/valid/interface_prefix.ts
@@ -1,4 +1,0 @@
-interface IStartedWithI {
-  bar: number
-  foo: string
-}


### PR DESCRIPTION
### 제안 내용
* 인터페이스의 네이밍 규칙에 적용된 헝가리안 케이싱을 제거합니다. 

### 근거
* IDE 등의 도움으로 특정 지시자가 인터페이스임을 유추할 수 있으므로, 별도의 표기법으로 강제할 필요는 없습니다.
* 현대 프레임워크에서 보통 인터페이스의 네이밍 규칙은 PascalCase 입니다. 
    * nestjs:    https://github.com/nestjs/nest/blob/ecdd86f688462ae717a621ee2c7be7b7ef53797d/packages/core/interfaces/module-override.interface.ts#L3C2-L6C2
    * spring: 
https://github.com/spring-projects/spring-framework/blob/bb23032a789d2110a0515a8ea62550fd01b75b71/spring-core/src/main/java/org/springframework/core/type/AnnotatedTypeMetadata.java#L53