### PR TITLE
feat: 변수이름 규칙에 strictCamelCase 적용

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,16 +9,16 @@ module.exports = {
       'error',
       {
         'selector': 'interface',
-        'format': ['PascalCase'],
+        'format': ['StrictPascalCase'],
         'prefix': ['I'],
       },
       {
         'selector': 'class',
-        'format': ['PascalCase'],
+        'format': ['StrictPascalCase'],
       },
       {
         'selector': ['classProperty', 'objectLiteralProperty'],
-        'format': ['snake_case', 'camelCase'],
+        'format': ['snake_case', 'strictCamelCase'],
       },
       {
         'selector': ['classProperty', 'objectLiteralProperty'],
@@ -27,7 +27,7 @@ module.exports = {
       },
       {
         'selector': ['enum'],
-        'format': ['UPPER_CASE', 'PascalCase'],
+        'format': ['UPPER_CASE', 'StrictPascalCase'],
       },
       {
         'selector': ['enumMember'],
@@ -35,7 +35,7 @@ module.exports = {
       },
       {
         'selector': 'variable',
-        'format': ['camelCase', 'UPPER_CASE'],
+        'format': ['strictCamelCase', 'UPPER_CASE'],
       },
       {
         'selector': 'variable',

--- a/tests/rules/naming-convention.spec.ts
+++ b/tests/rules/naming-convention.spec.ts
@@ -26,14 +26,36 @@ describe('Flitto Custom Naming Convention Linting Rule Test', () => {
       expect(results[0].messages.length).toEqual(0)
     })
 
+    it('인터페이스의 이름이 StrictPascalCase(e.g., ID(X)->Id(O) or DTO(X)->Dto(O)) 가 아닌 경우 린트에러가 발생합니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'interface_name_not_as_strict_camel_case.ts'))
+      expect(results[0].messages.length).toEqual(1)
+      expect(results[0].messages[0].message).toEqual('Interface name `INotStrictCamelCaseID` trimmed as `NotStrictCamelCaseID` must match one of the following formats: StrictPascalCase')
+    })
+
+    it('인터페이스의 이름은 StrictPascalCase(e.g., ID(X)->Id(O) or DTO(X)->Dto(O)) 이어야 합니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, VALID, 'interface_name_as_strict_camel_case.ts'))
+      expect(results[0].messages.length).toEqual(0)
+    })
+
     it('클래스의 이름이 PascalCase 가 아니라면 린트에러가 발생합니다.', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'class_name_as_camel_case.ts'))
       expect(results[0].messages.length).toEqual(1)
-      expect(results[0].messages[0].message).toEqual('Class name `camelCaseClass` must match one of the following formats: PascalCase')
+      expect(results[0].messages[0].message).toEqual('Class name `camelCaseClass` must match one of the following formats: StrictPascalCase')
     })
 
     it('클래스의 이름은 PascalCase 이어야 합니다.', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, VALID, 'class_name_casing.ts'))
+      expect(results[0].messages.length).toEqual(0)
+    })
+
+    it('클래스의 이름이 StrictPascalCase(e.g., ID(X)->Id(O) or DTO(X)->Dto(O)) 가 아닌 경우 린트에러가 발생합니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'class_name_not_as_strict_camel_case.ts'))
+      expect(results[0].messages.length).toEqual(1)
+      expect(results[0].messages[0].message).toEqual('Class name `NotStrictCamelCaseID` must match one of the following formats: StrictPascalCase')
+    })
+
+    it('클래스의 이름은 StrictPascalCase(e.g., ID(X)->Id(O) or DTO(X)->Dto(O)) 이어야 합니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, VALID, 'class_name_as_strict_camel_case.ts'))
       expect(results[0].messages.length).toEqual(0)
     })
 
@@ -51,7 +73,7 @@ describe('Flitto Custom Naming Convention Linting Rule Test', () => {
     it('클래스의 프로퍼티가 PascalCase 인 경우 린트에러가 발생합니다.', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'class_property_as_pascal_case.ts'))
       expect(results[0].messages.length).toEqual(1)
-      expect(results[0].messages[0].message).toEqual('Class Property name `PropertyPascal` must match one of the following formats: snake_case, camelCase')
+      expect(results[0].messages[0].message).toEqual('Class Property name `PropertyPascal` must match one of the following formats: snake_case, strictCamelCase')
     })
 
     it('클래스의 프로퍼티는 camelCase 이거나 snake_case 이어야 합니다.', async () => {
@@ -67,7 +89,7 @@ describe('Flitto Custom Naming Convention Linting Rule Test', () => {
     it('enum 명이 pascalCase 라면 린트에러가 발생합니다.', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'enum_name_as_pascal_case.ts'))
       expect(results[0].messages.length).toEqual(1)
-      expect(results[0].messages[0].message).toEqual('Enum name `pascalCaseEnum` must match one of the following formats: UPPER_CASE, PascalCase')
+      expect(results[0].messages[0].message).toEqual('Enum name `pascalCaseEnum` must match one of the following formats: UPPER_CASE, StrictPascalCase')
     })
 
     it('enum 프로퍼티가 UPPER_CASE 가 아니라면 린트에러가 발생합니다.', async () => {
@@ -84,18 +106,35 @@ describe('Flitto Custom Naming Convention Linting Rule Test', () => {
     it('snake_case 인 변수는 허용되지 않습니다.', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'variable_as_snake_case.ts'))
       expect(results[0].messages.length).toEqual(1)
-      expect(results[0].messages[0].message).toEqual('Variable name `snake_case_var` must match one of the following formats: camelCase, UPPER_CASE')
+      expect(results[0].messages[0].message).toEqual('Variable name `snake_case_var` must match one of the following formats: strictCamelCase, UPPER_CASE')
     })
 
     it('PascalCase 인 변수는 허용되지 않습니다.', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'variable_as_pascal_case.ts'))
       expect(results[0].messages.length).toEqual(1)
-      expect(results[0].messages[0].message).toEqual('Variable name `PascalCaseVar2` must match one of the following formats: camelCase, UPPER_CASE')
+      expect(results[0].messages[0].message).toEqual('Variable name `PascalCaseVar2` must match one of the following formats: strictCamelCase, UPPER_CASE')
+    })
+
+    it('변수이름이 StrictPascalCase(e.g., ID(X)->Id(O) or DTO(X)->Dto(O))로 작성되지 않은 경우 린트 에러가 발생합니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'variable_not_as_strict_camel_case.ts'))
+      expect(results[0].messages.length).toEqual(1)
+      expect(results[0].messages[0].message).toEqual('Variable name `usingStrictNamingDTO` must match one of the following formats: strictCamelCase, UPPER_CASE')
     })
 
     it('변수이름에는 camelCase, UPPER_CASE 만이 허용됩니다.', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, VALID, 'variable_name_casing.ts'))
       expect(results[0].messages.length).toEqual(0)
+    })
+
+    it('변수이름이 camelCase 인 경우 strictCamelCase(e.g., ID(X)->Id(O) or DTO(X)->Dto(O)) 이어야 합니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, VALID, 'variable_as_strict_camel_case.ts'))
+      expect(results[0].messages.length).toEqual(0)
+    })
+
+    it('변수이름에는 StrictPascalCase(e.g., ID(X)->Id(O) or DTO(X)->Dto(O)) 만이 허용됩니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'variable_not_as_strict_camel_case.ts'))
+      expect(results[0].messages.length).toEqual(1)
+      expect(results[0].messages[0].message).toEqual('Variable name `usingStrictNamingDTO` must match one of the following formats: strictCamelCase, UPPER_CASE')
     })
   })
 })

--- a/tests/rules/target/naming-convention/invalid/class_name_not_as_strict_camel_case.ts
+++ b/tests/rules/target/naming-convention/invalid/class_name_not_as_strict_camel_case.ts
@@ -1,0 +1,4 @@
+class NotStrictCamelCaseID {
+  bar: number
+  foo: string
+}

--- a/tests/rules/target/naming-convention/invalid/interface_name_not_as_strict_camel_case.ts
+++ b/tests/rules/target/naming-convention/invalid/interface_name_not_as_strict_camel_case.ts
@@ -1,0 +1,4 @@
+interface INotStrictCamelCaseID {
+  bar: number
+  foo: string
+}

--- a/tests/rules/target/naming-convention/invalid/variable_not_as_strict_camel_case.ts
+++ b/tests/rules/target/naming-convention/invalid/variable_not_as_strict_camel_case.ts
@@ -1,0 +1,1 @@
+const usingStrictNamingDTO: string = 'one'

--- a/tests/rules/target/naming-convention/valid/class_name_as_strict_camel_case.ts
+++ b/tests/rules/target/naming-convention/valid/class_name_as_strict_camel_case.ts
@@ -1,0 +1,9 @@
+class StrictCamelCaseId {
+  bar: number
+  foo: string
+}
+
+class StrictCamelCaseDto {
+  bar: number
+  foo: string
+}

--- a/tests/rules/target/naming-convention/valid/interface_name_as_strict_camel_case.ts
+++ b/tests/rules/target/naming-convention/valid/interface_name_as_strict_camel_case.ts
@@ -1,0 +1,9 @@
+interface IStrictCamelCaseId {
+  bar: number
+  foo: string
+}
+
+interface IStrictCamelCaseDto {
+  bar: number
+  foo: string
+}

--- a/tests/rules/target/naming-convention/valid/variable_as_strict_camel_case.ts
+++ b/tests/rules/target/naming-convention/valid/variable_as_strict_camel_case.ts
@@ -1,0 +1,3 @@
+const usingDto: string = 'one'
+const usedForId: string = 'two'
+const urlForIos: string = 'https://...'

--- a/tests/rules/target/naming-convention/valid/variable_name_casing.ts
+++ b/tests/rules/target/naming-convention/valid/variable_name_casing.ts
@@ -1,3 +1,5 @@
 const UPPER_CASE_12: number = 12
 const camelCase13: number = 13
 const original: string = 'origin'
+const usingStringNamingDto: string = 'one'
+const usedId: string = 'two'


### PR DESCRIPTION
### 내용
* StrictPascalCase 와 strictCamelCase 를 적용합니다. https://typescript-eslint.io/rules/naming-convention/#format-options
    * somethingID ❌, somethingId ✅
    * somethingDTO ❌, somethingDto ✅

### 근거
* [구글 자바스크립트 스타일가이드: camel case](https://google.github.io/styleguide/jsguide.html#naming-camel-case-defined)
* Webstorm IDE 에서 클래스명과 파일명 매칭을 Strict 한 방법을 기반으로 함
    * `class WebstormIdeConfig` 명은 `webstorm_ide_config.ts` 라는 파일명에 대응됨
    * `class WebstormIDEConfig` 명은 `webstorm_i_d_e_config.ts` 라는 파일명에 대응됨
    * 웹스톰 설정: Editor > Code Style > Typescript > Naming Conventions > Filename convention
    <image src="https://github.com/flitto/eslint-config-flitto-typescript/assets/32891887/a5e6e7e5-15a0-46d1-adf2-3d40f722a805" width="450px"/>
