### PR TITLE
feat: property 키 이름 규칙 재정의

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,13 +17,13 @@ module.exports = {
         'format': ['PascalCase'],
       },
       {
-        'selector': ['classProperty', 'objectLiteralProperty'],
-        'format': ['snake_case', 'camelCase'],
+        'selector': ['property'],
+        'format': ['snake_case', 'camelCase', 'PascalCase', 'UPPER_CASE'],
       },
       {
-        'selector': ['classProperty', 'objectLiteralProperty'],
-        'modifiers': ['readonly', 'static'],
-        'format': ['UPPER_CASE'],
+        'selector': ['property'],
+        'modifiers': ['requiresQuotes'],
+        'format': null,
       },
       {
         'selector': ['enum'],

--- a/tests/rules/naming-convention.spec.ts
+++ b/tests/rules/naming-convention.spec.ts
@@ -37,26 +37,15 @@ describe('Flitto Custom Naming Convention Linting Rule Test', () => {
       expect(results[0].messages.length).toEqual(0)
     })
 
-    it('클래스의 readonly 멤버가 UPPER_CASE 가 아니라면 린트에러가 발생합니다.', async () => {
-      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'class_property_static_readonly_no_upper_casing.ts'))
-      expect(results[0].messages.length).toEqual(1)
-      expect(results[0].messages[0].message).toEqual('Class Property name `upperCase` must match one of the following formats: UPPER_CASE')
-    })
-
-    it('클래스의 static readonly 멤버는 UPPER_CASE 이어야 합니다.', async () => {
-      const results = await lint.lintFiles(Path.join(targetDir, VALID, 'class_property_static_readonly_upper_casing.ts'))
-      expect(results[0].messages.length).toEqual(0)
-    })
-
-    it('클래스의 프로퍼티가 PascalCase 인 경우 린트에러가 발생합니다.', async () => {
-      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'class_property_as_pascal_case.ts'))
-      expect(results[0].messages.length).toEqual(1)
-      expect(results[0].messages[0].message).toEqual('Class Property name `PropertyPascal` must match one of the following formats: snake_case, camelCase')
-    })
-
-    it('클래스의 프로퍼티는 camelCase 이거나 snake_case 이어야 합니다.', async () => {
+    it('클래스의 프로퍼티는 camelCase, snake_case, PascalCase 또는 UPPER_CASE 이어야 합니다. (requiresQuotes 인 경우 네이밍 룰 해제)', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, VALID, 'class_property_casing.ts'))
       expect(results[0].messages.length).toEqual(0)
+    })
+
+    it('변수의 이름 앞 뒤로 underscore(`_`) 가 포함된 경우 린트 에러가 발생합니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'class_property_underscored.ts'))
+      expect(results[0].messages.length).toEqual(6)
+      // expect(results[0].messages[0].message).toEqual('Variable name `PascalCaseVar2` must match one of the following formats: camelCase, UPPER_CASE')
     })
 
     it('object 의 프로퍼티는 camelCase 이거나 snake_case 이어야 합니다.', async () => {

--- a/tests/rules/target/naming-convention/invalid/class_property_as_pascal_case.ts
+++ b/tests/rules/target/naming-convention/invalid/class_property_as_pascal_case.ts
@@ -1,4 +1,0 @@
-class PropertyCasingInvalid {
-  property_snake: number
-  PropertyPascal: number
-}

--- a/tests/rules/target/naming-convention/invalid/class_property_static_readonly_no_upper_casing.ts
+++ b/tests/rules/target/naming-convention/invalid/class_property_static_readonly_no_upper_casing.ts
@@ -1,4 +1,0 @@
-class UpperCasingClass {
-  static readonly upperCase: string
-  extra: string
-}

--- a/tests/rules/target/naming-convention/invalid/class_property_underscored.ts
+++ b/tests/rules/target/naming-convention/invalid/class_property_underscored.ts
@@ -1,0 +1,8 @@
+class PropertyCasingInvalidUnderscore {
+  _uuid: string
+  __uuid: string
+  ___uuid: string
+  uuid_: string
+  uuid__: string
+  uuid___: string
+}

--- a/tests/rules/target/naming-convention/valid/class_property_casing.ts
+++ b/tests/rules/target/naming-convention/valid/class_property_casing.ts
@@ -1,6 +1,7 @@
 class PropertyCasingValid {
-  show: number
-  me: string
-  the_money: string
-  forAddon: number
+  property_snake: number
+  propertyCamel: number
+  PropertyPascal: number
+  PROPERTY_UPPER: number
+  'Hyphenated-Property-Casing': number
 }

--- a/tests/rules/target/naming-convention/valid/class_property_static_readonly_upper_casing.ts
+++ b/tests/rules/target/naming-convention/valid/class_property_static_readonly_upper_casing.ts
@@ -1,4 +1,0 @@
-class UpperCasingClassValid {
-  static readonly UPPER_CASE: string
-  extra: string
-}


### PR DESCRIPTION
### 내용 
* 프로퍼티(property) 규칙 완화: PascalCase 허용
    * aws SDK 등의 프로퍼티가 PascalCase 로 선언되어 있는 경우가 있음
https://github.com/flitto/bms-service/blob/f63b2b1a89f38ffef800515a1b9b4e56c11554bb/src/modules/route-53/route53.service.ts#L18-L33
* 따옴표가 필요한 키(modifiers: requiresQuotes)의 경우 네이밍 룰 적용하지 않음
```ts
// html 헤더를 명시하는 경우에는 네이밍 룰 적용 해제
const htmlHeader = {
  'Content-Type': "image/*"',
}
```

--- 
### 참고
* 💡 property 셀렉터는 class property, object literal property, type property 를 의미합니다. https://typescript-eslint.io/rules/naming-convention/#format-options