### PR TITLE
feat: prettier 의 bracketSameLine 옵션 해제

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ module.exports = {
       'singleQuote': true,
       'semi': false,
       'tabWidth': 2,
-      'printWidth': 140
+      'printWidth': 140,
+      'bracketSameLine': false,
     }]
   },
   reportUnusedDisableDirectives: true,


### PR DESCRIPTION
### 내용
* prettier 에서 bracketSameLine 룰을 false 로 하기

### 참조
* https://prettier.io/docs/en/options.html#bracket-line
* https://github.com/flitto/ent-workspace/blob/c46cac24eb0698afbaf9fb18ea84958e2cd83058/components/base/textInput/number-input.vue#L27-L39

```vue
    <span
      v-show="!isInputView"
      class="number-input__viewer"
      :class="{
        'left-icon': $attrs.leftIcon,
        'right-icon': $attrs.rightIcon,
        error: $attrs.isError,
      }"
      v-bind="$attrs"
      @click="onInputView"
    >
      {{ localNumber }}
    </span>
```