### PR TITLE
refactor: 프로퍼티가 _id, __v 인 경우 예외적으로 허용합니다.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,14 @@ module.exports = {
         'format': null,
       },
       {
+        'selector': ['property'],
+        'filter': {
+          'regex': '^_id$',
+          'match': true,
+        },
+        'format': null,
+      },
+      {
         'selector': ['enum'],
         'format': ['UPPER_CASE', 'StrictPascalCase'],
       },

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
       {
         'selector': ['property'],
         'filter': {
-          'regex': '^_id$',
+          'regex': '^(_id|__v)$',
           'match': true,
         },
         'format': null,

--- a/tests/rules/naming-convention.spec.ts
+++ b/tests/rules/naming-convention.spec.ts
@@ -114,5 +114,16 @@ describe('Flitto Custom Naming Convention Linting Rule Test', () => {
       expect(results[0].messages.length).toEqual(1)
       expect(results[0].messages[0].message).toEqual('Variable name `usingStrictNamingDTO` must match one of the following formats: strictCamelCase, UPPER_CASE')
     })
+
+    it('클래스의 프로퍼티가 _id 인 경우 예외적으로 허용합니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, VALID, 'class_property_casing_by_filter.ts'))
+      expect(results[0].messages.length).toEqual(0)
+    })
+
+    it('클래스의 프로퍼티가 예외 케이스를 제외한 기존 린트에러가 정상작동 하는지 테스트 합니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'class_property_not_as_filter.ts'))
+      expect(results[0].messages.length).toEqual(2)
+      expect(results[0].messages[0].message).toEqual('Class Property name `_id_` must match one of the following formats: snake_case, strictCamelCase, StrictPascalCase, UPPER_CASE')
+    })
   })
 })

--- a/tests/rules/naming-convention.spec.ts
+++ b/tests/rules/naming-convention.spec.ts
@@ -120,10 +120,11 @@ describe('Flitto Custom Naming Convention Linting Rule Test', () => {
       expect(results[0].messages.length).toEqual(0)
     })
 
-    it('클래스의 프로퍼티가 예외 케이스를 제외한 기존 린트에러가 정상작동 하는지 테스트 합니다.', async () => {
+    it('클래스의 프로퍼티가 _id, __v 가 아닌 경우 기존 린트에러가 발생 합니다.', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'class_property_not_as_filter.ts'))
       expect(results[0].messages.length).toEqual(4)
       expect(results[0].messages[0].message).toEqual('Class Property name `_id_` must match one of the following formats: snake_case, strictCamelCase, StrictPascalCase, UPPER_CASE')
+      expect(results[0].messages[2].message).toEqual('Class Property name `___v` must match one of the following formats: snake_case, strictCamelCase, StrictPascalCase, UPPER_CASE')
     })
   })
 })

--- a/tests/rules/naming-convention.spec.ts
+++ b/tests/rules/naming-convention.spec.ts
@@ -115,14 +115,14 @@ describe('Flitto Custom Naming Convention Linting Rule Test', () => {
       expect(results[0].messages[0].message).toEqual('Variable name `usingStrictNamingDTO` must match one of the following formats: strictCamelCase, UPPER_CASE')
     })
 
-    it('클래스의 프로퍼티가 _id 인 경우 예외적으로 허용합니다.', async () => {
+    it('클래스의 프로퍼티가 _id, __v 인 경우 예외적으로 허용합니다.', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, VALID, 'class_property_casing_by_filter.ts'))
       expect(results[0].messages.length).toEqual(0)
     })
 
     it('클래스의 프로퍼티가 예외 케이스를 제외한 기존 린트에러가 정상작동 하는지 테스트 합니다.', async () => {
       const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'class_property_not_as_filter.ts'))
-      expect(results[0].messages.length).toEqual(2)
+      expect(results[0].messages.length).toEqual(4)
       expect(results[0].messages[0].message).toEqual('Class Property name `_id_` must match one of the following formats: snake_case, strictCamelCase, StrictPascalCase, UPPER_CASE')
     })
   })

--- a/tests/rules/target/naming-convention/invalid/class_property_not_as_filter.ts
+++ b/tests/rules/target/naming-convention/invalid/class_property_not_as_filter.ts
@@ -1,5 +1,8 @@
-class PropertyCasingInvalidUnderscore {
+class PropertyCasingInvalidByFilter {
   _id: string
   _id_: string
   _id_id: string
+  __v: string
+  ___v: string
+  __v_v: string
 }

--- a/tests/rules/target/naming-convention/invalid/class_property_not_as_filter.ts
+++ b/tests/rules/target/naming-convention/invalid/class_property_not_as_filter.ts
@@ -1,8 +1,6 @@
 class PropertyCasingInvalidByFilter {
-  _id: string
   _id_: string
   _id_id: string
-  __v: string
   ___v: string
   __v_v: string
 }

--- a/tests/rules/target/naming-convention/invalid/class_property_not_as_filter.ts
+++ b/tests/rules/target/naming-convention/invalid/class_property_not_as_filter.ts
@@ -1,0 +1,5 @@
+class PropertyCasingInvalidUnderscore {
+  _id: string
+  _id_: string
+  _id_id: string
+}

--- a/tests/rules/target/naming-convention/valid/class_property_casing_by_filter.ts
+++ b/tests/rules/target/naming-convention/valid/class_property_casing_by_filter.ts
@@ -1,0 +1,3 @@
+class PropertyCasingValidByFilter {
+  _id: string // MongoDB "_id" 인 경우
+}

--- a/tests/rules/target/naming-convention/valid/class_property_casing_by_filter.ts
+++ b/tests/rules/target/naming-convention/valid/class_property_casing_by_filter.ts
@@ -1,3 +1,4 @@
 class PropertyCasingValidByFilter {
   _id: string // MongoDB "_id" 인 경우
+  __v: string // MongoDB "__v" 인 경우
 }

--- a/tests/rules/target/naming-convention/valid/class_property_casing_by_filter.ts
+++ b/tests/rules/target/naming-convention/valid/class_property_casing_by_filter.ts
@@ -1,3 +1,4 @@
+// https://github.com/Automattic/mongoose/blob/582156858db3ca7fbaa8950dc997e0d9e8117b21/types/document.d.ts#L22-L26
 class PropertyCasingValidByFilter {
   _id: string // MongoDB "_id" 인 경우
   __v: string // MongoDB "__v" 인 경우


### PR DESCRIPTION
### 주요내용
- `_id`, `__v` 프로퍼티의 경우 예외적으로 허용하도록 합니다.
- 관련하여 테스트케이스를 2개 추가합니다.

#### 허용 이유
- mongodb `_id` , `__v` 에서 ESLint 에러 발생
<img width="1589" alt="스크린샷 2023-10-31 오후 7 03 07" src="https://github.com/flitto/eslint-config-flitto-typescript/assets/44458177/b49e9163-6f0e-42df-87e1-84e2c1a2741e">


#### 허용 방법
- [ESLint filter (Regex)](https://typescript-eslint.io/rules/naming-convention/#filter)

#### 허용 후  테스트
<img width="396" alt="스크린샷 2023-10-31 오후 7 02 27" src="https://github.com/flitto/eslint-config-flitto-typescript/assets/44458177/35b03af2-388e-477d-ad17-ece4901933e6">