### PR TITLE
feat: To 1.3.0 override strict-boolean-expression

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,62 +1,62 @@
 module.exports = {
-  extends: [
-    'love',
-    'prettier'
-  ],
+  extends: ['love', 'prettier'],
   plugins: ['prettier'],
   rules: {
     '@typescript-eslint/naming-convention': [
       'error',
       {
-        'selector': 'interface',
-        'format': ['StrictPascalCase'],
+        selector: 'interface',
+        format: ['StrictPascalCase'],
       },
       {
-        'selector': 'class',
-        'format': ['StrictPascalCase'],
+        selector: 'class',
+        format: ['StrictPascalCase'],
       },
       {
-        'selector': ['property'],
-        'format': ['snake_case', 'strictCamelCase', 'StrictPascalCase', 'UPPER_CASE'],
+        selector: ['property'],
+        format: ['snake_case', 'strictCamelCase', 'StrictPascalCase', 'UPPER_CASE'],
       },
       {
-        'selector': ['property'],
-        'modifiers': ['requiresQuotes'],
-        'format': null,
+        selector: ['property'],
+        modifiers: ['requiresQuotes'],
+        format: null,
       },
       {
-        'selector': ['property'],
-        'filter': {
-          'regex': '^(_id|__v)$',
-          'match': true,
+        selector: ['property'],
+        filter: {
+          regex: '^(_id|__v)$',
+          match: true,
         },
-        'format': null,
+        format: null,
       },
       {
-        'selector': ['enum'],
-        'format': ['UPPER_CASE', 'StrictPascalCase'],
+        selector: ['enum'],
+        format: ['UPPER_CASE', 'StrictPascalCase'],
       },
       {
-        'selector': ['enumMember'],
-        'format': ['UPPER_CASE'],
+        selector: ['enumMember'],
+        format: ['UPPER_CASE'],
       },
       {
-        'selector': 'variable',
-        'format': ['strictCamelCase', 'UPPER_CASE'],
+        selector: 'variable',
+        format: ['strictCamelCase', 'UPPER_CASE'],
       },
       {
-        'selector': 'variable',
-        'modifiers': ['destructured'],
-        'format': null,
+        selector: 'variable',
+        modifiers: ['destructured'],
+        format: null,
       },
     ],
-    'prettier/prettier': ['error', {
-      'singleQuote': true,
-      'semi': false,
-      'tabWidth': 2,
-      'printWidth': 140,
-      'bracketSameLine': false,
-    }]
+    'prettier/prettier': [
+      'error',
+      {
+        singleQuote: true,
+        semi: false,
+        tabWidth: 2,
+        printWidth: 140,
+        bracketSameLine: false,
+      },
+    ],
   },
   reportUnusedDisableDirectives: true,
 }

--- a/index.js
+++ b/index.js
@@ -57,6 +57,18 @@ module.exports = {
         bracketSameLine: false,
       },
     ],
+    '@typescript-eslint/strict-boolean-expressions': [
+      'error',
+      {
+        allowString: false,
+        allowNumber: false,
+        allowNullableObject: true,
+        allowNullableBoolean: false,
+        allowNullableString: false,
+        allowNullableNumber: false,
+        allowAny: false,
+      },
+    ],
   },
   reportUnusedDisableDirectives: true,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-config-flitto-typescript",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-config-flitto-typescript",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "eslint-config-love": "^47.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-flitto-typescript",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "ESlint configuration for Flitto projects",
   "main": "index.js",
   "scripts": {

--- a/tests/rules/strict-boolean-expression.spec.ts
+++ b/tests/rules/strict-boolean-expression.spec.ts
@@ -1,0 +1,35 @@
+import { ESLint } from 'eslint'
+import * as Path from 'path'
+import config from '../../index'
+
+const INVALID = 'invalid'
+const VALID = 'valid'
+
+describe('Flitto Custom Strict Boolean Expression Linting Rule Test', () => {
+  let lint: ESLint
+  beforeAll(() => {
+    config.parserOptions = { project: ['tsconfig.json'] }
+    config.rules = { ...config.rules, '@typescript-eslint/no-unused-vars': 'off' } // 테스트시에 no-unused-vars 규칙은 제외합니다.
+    lint = new ESLint({ baseConfig: config })
+  })
+
+  describe('@typescript-eslint/strict-boolean-expression', () => {
+    const targetDir = 'tests/rules/target/strict-boolean-expression'
+    it('number 타입일 수 있는 변수는 조건으로 사용할 수 없습니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'number_as_condition.ts'))
+      expect(results[0].messages.length).toEqual(1)
+      expect(results[0].messages[0].messageId).toEqual('conditionErrorNullableNumber')
+    })
+
+    it('string 타입일 수 있는 변수는 조건으로 사용할 수 없습니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, INVALID, 'string_as_condition.ts'))
+      expect(results[0].messages.length).toEqual(1)
+      expect(results[0].messages[0].messageId).toEqual('conditionErrorNullableString')
+    })
+
+    it('object 타입일 수 있는 변수는 조건으로 사용할 수 있습니다.', async () => {
+      const results = await lint.lintFiles(Path.join(targetDir, VALID, 'object_as_condition.ts'))
+      expect(results[0].messages.length).toEqual(0)
+    })
+  })
+})

--- a/tests/rules/target/strict-boolean-expression/invalid/number_as_condition.ts
+++ b/tests/rules/target/strict-boolean-expression/invalid/number_as_condition.ts
@@ -1,0 +1,5 @@
+const num: number | undefined = Math.random() > 0.5 ? 123 : undefined
+
+if (num) {
+  console.log('num is defined')
+}

--- a/tests/rules/target/strict-boolean-expression/invalid/string_as_condition.ts
+++ b/tests/rules/target/strict-boolean-expression/invalid/string_as_condition.ts
@@ -1,0 +1,5 @@
+const str: string | null = Math.random() > 0.5 ? 'Some string' : null
+
+if (str) {
+  console.log('str is defined')
+}

--- a/tests/rules/target/strict-boolean-expression/valid/object_as_condition.ts
+++ b/tests/rules/target/strict-boolean-expression/valid/object_as_condition.ts
@@ -1,0 +1,25 @@
+interface Room {
+  id: number
+  name: string
+}
+const rooms: Room[] = [
+  {
+    id: 1,
+    name: 'Babylon',
+  },
+  {
+    id: 2,
+    name: 'Pangea',
+  },
+  {
+    id: 3,
+    name: 'Agora',
+  },
+]
+
+const getRandomId = (): number => Math.floor(Math.random() * 10)
+const foundRoom: Room | undefined = rooms.find(({ id }) => id === getRandomId())
+
+if (foundRoom) {
+  console.log('Nullable objects are allowed as a condition')
+}


### PR DESCRIPTION
* strict-boolean-expression 에서 allowNullableObject 옵션을 true 로 합니다.
* (기타) style 적용, 관련 테스트 케이스 추가
* commit 단위로 보시길 권장드립니다.

> [!NOTE]
> 이번에 eslint 의 [flatConfig](https://eslint.org/docs/v8.x/use/configure/configuration-files-new) 내용을 적용하여 2.0.0 버전으로 업데이트를 진행하려고 하였으나, eslint 8.57 버전 (eslint-config-love@>=47 는 flatConfig 만을 지원하는 것으로 보임)의Node API 를 활용하여 테스트 케이스를 실행시키는 부분에서 막혀 더 이상 진행하지 못했습니다. (변경된 설정이 node API 부분에서는 제대로 지원되지 않는 것으로 보임, 8.57 은 9 로 가는 과도기적인 단계로 마이너한 부분에서 맞지 않는 부분이 있는 것으로 사료됨)
>
> 현재 eslint 의 최신버전은 9.8 버전이며, config 를 지정하는 방식에서 많은 변화가 있는 것으로 보입니다. eslint-config-love (본 설정이 의존하는) 는 아직 eslint@8.57 을 의존하고 있으며 [9으로의 이관을 준비하고 있는 것](https://github.com/mightyiam/eslint-config-love/pull/1497#issuecomment-2132264815)으로 보입니다. 8.57 로 갔다가 9 버전으로 가는 것도 의미가 있겠으나, eslint-config-love 가 eslint@9 를 공식적으로 의존할 때 저희도 eslint@9 에 맞춰 업데이트를 진행하고 2.0.0 버전으로 업데이트 하는 계획을 진행해보면 좋을 것 같습니다.